### PR TITLE
Fixed documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ use AuditStash\PersisterInterface;
 
 class DatabasePersister implements PersisterInterface
 {
-    public function logEvents(array $logs)
+    public function logEvents(array $auditLogs)
     {
         foreach ($auditLogs as $log) {
             $eventType = $log->getEventType();
@@ -236,7 +236,7 @@ lines:
 'AuditStash' => ['persister' => 'App\Namespace\For\Your\DatabasePersister']
 ```
 
-or if you are using as standalone via 
+or if you are using as standalone via
 
 ```php
 \Cake\Core\Configure::write('AuditStash.presister', 'App\Namespace\For\Your\DatabasePersister');

--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -34,7 +34,7 @@ class AuditLogBehavior extends Behavior
     ];
 
     /**
-     * The persiter object
+     * The persister object
      *
      * @var PersisterInterface
      */

--- a/src/PersisterInterface.php
+++ b/src/PersisterInterface.php
@@ -10,7 +10,7 @@ namespace AuditStash;
 interface PersisterInterface
 {
     /**
-     * Persists each od the passed EventInterface objects
+     * Persists each of the passed EventInterface objects
      *
      * @param array $auditLogs List of EventInterface objects to persist
      * @return void


### PR DESCRIPTION
I started using this Plugin and found some typos on the documentation.

Thanks for your amazing work!
