### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ class DatabasePersister implements PersisterInterface
                 'primary_key' => $log->getId(),
                 'source' => $log->getSourceName(),
                 'parent_source' => $log->getParentSourceName(),
-                'changed' => $eventType === 'delete' ? null : $log->getChanged(),
-                'meta' => $log->getMetaInfo()
+                'original' => json_encode($log->getOriginal()),
+                'changed' => $eventType === 'delete' ? null : json_encode($log->getChanged()),
+                'meta' => json_encode($log->getMetaInfo())
             ];
             TableRegistry::get('MyAuditsTable')->save(new Entity($data));
         }
@@ -245,7 +246,7 @@ lines:
 or if you are using as standalone via
 
 ```php
-\Cake\Core\Configure::write('AuditStash.presister', 'App\Namespace\For\Your\DatabasePersister');
+\Cake\Core\Configure::write('AuditStash.persister', 'App\Namespace\For\Your\DatabasePersister');
 ```
 
 The configuration contains the fully namespaced class name of your persister.


### PR DESCRIPTION
Updates in implementing our own persister strategy. Added json_encode for 'changed' and 'meta' fields as they are strings and weren't being saved without encoding them. Also added the 'original' field which tells the original state of the data before it was changed. 
P.S. there was a little typo on line 248.