### PR TITLE
Enhance table/database persisting functionality.

### DIFF
--- a/src/Persister/DatabasePersister.php
+++ b/src/Persister/DatabasePersister.php
@@ -12,6 +12,7 @@ use DateTime;
  *
  * @package App\Persister
  * @author Cake Development Corporation
+ * @deprecated Use \AuditStash\Persister\TablePersister instead.
  */
 class DatabasePersister implements PersisterInterface
 {

--- a/src/Persister/ExtractionTrait.php
+++ b/src/Persister/ExtractionTrait.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace AuditStash\Persister;
+
+use AuditStash\Event\BaseEvent;
+use AuditStash\EventInterface;
+use Cake\Utility\Hash;
+
+trait ExtractionTrait
+{
+    /**
+     * Extracts the basic fields from the audit event object.
+     *
+     * @param \AuditStash\EventInterface $event The event object from which to extract the fields.
+     * @param bool $serialize Whether to serialize fields that are expected to hold array data.
+     * @return array
+     */
+    protected function extractBasicFields(EventInterface $event, $serialize = true)
+    {
+        $fields = [
+            'transaction' => $event->getTransactionId(),
+            'type' => $event->getEventType(),
+            'source' => $event->getSourceName(),
+            'parent_source' => null,
+            'original' => null,
+            'changed' => null,
+            'created' => new \DateTime($event->getTimestamp())
+        ];
+
+        if (method_exists($event, 'getParentSourceName')) {
+            $fields['parent_source'] = $event->getParentSourceName();
+        }
+
+        if ($event instanceof BaseEvent) {
+            $fields['original'] = $serialize ? $this->serialize($event->getOriginal()) : $event->getOriginal();
+            $fields['changed'] = $serialize ? $this->serialize($event->getChanged()) : $event->getChanged();
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Extracts the primary key fields from the audit event object.
+     *
+     * @param \AuditStash\EventInterface $event The event object from which to extract the primary key.
+     * @param string $strategy The strategy to use for extracting the primary key.
+     * @return array
+     */
+    protected function extractPrimaryKeyFields(EventInterface $event, $strategy = 'automatic')
+    {
+        $primaryKeyFields = [];
+
+        switch ($strategy) {
+            case 'automatic':
+                $id = (array)$event->getId();
+                if (count($id) === 1) {
+                    $id = array_pop($id);
+                } else {
+                    $id = $this->serialize($id);
+                }
+                $primaryKeyFields['primary_key'] = $id;
+                break;
+
+            case 'properties':
+                $id = (array)$event->getId();
+                if (count($id) === 1) {
+                    $primaryKeyFields['primary_key'] = array_pop($id);
+                } else {
+                    foreach ($id as $key => $value) {
+                        $primaryKeyFields['primary_key_' . $key] = $value;
+                    }
+                }
+                break;
+
+            case 'raw':
+                $primaryKeyFields['primary_key'] = $event->getId();
+                break;
+
+            case 'serialized':
+                $id = $event->getId();
+                $primaryKeyFields['primary_key'] = $this->serialize($id);
+                break;
+        }
+
+        return $primaryKeyFields;
+    }
+
+    /**
+     * Extracts the metadata fields from the audit event object.
+     *
+     * @param \AuditStash\EventInterface $event The event object from which to extract the metadata fields.
+     * @param array|bool $fields Which/whether meta data fields should be extracted.
+     * @param bool $unsetExtracted Whether the fields extracted from the meta data should be unset.
+     * @param bool $serialize Whether to serialize fields that are expected to hold array data.
+     * @return array
+     */
+    protected function extractMetaFields(EventInterface $event, $fields, $unsetExtracted = true, $serialize = true)
+    {
+        $extracted = [
+            'meta' => $event->getMetaInfo()
+        ];
+
+        if (!is_array($extracted['meta'])) {
+            return $extracted;
+        }
+
+        if (!$fields ||
+            empty($extracted['meta'])
+        ) {
+            if ($serialize) {
+                $extracted['meta'] = $this->serialize($extracted['meta']);
+            }
+
+            return $extracted;
+        }
+
+        if ($fields === true) {
+            $extracted += $extracted['meta'];
+
+            if (!$unsetExtracted) {
+                if ($serialize) {
+                    $extracted['meta'] = $this->serialize($extracted['meta']);
+                }
+
+                return $extracted;
+            }
+
+            $extracted['meta'] = $serialize ? $this->serialize([]) : [];
+
+            return $extracted;
+        }
+
+        if (is_array($fields)) {
+            foreach ($fields as $name => $alias) {
+                if (!is_string($name)) {
+                    $name = $alias;
+                }
+
+                $extracted[$alias] = Hash::get($extracted['meta'], $name);
+                if ($unsetExtracted) {
+                    $extracted['meta'] = Hash::remove($extracted['meta'], $name);
+                }
+            }
+        }
+
+        if ($serialize) {
+            $extracted['meta'] = $this->serialize($extracted['meta']);
+        }
+
+        return $extracted;
+    }
+
+    /**
+     * Serializes a value to JSON.
+     *
+     * In case the value is `null`, the value is not being JSON encoded (which would turn it
+     * into a string), but returned as is, ie `null` is being returned.
+     *
+     * @param mixed $value The value to convert to JSON.
+     * @return string|null
+     */
+    protected function serialize($value)
+    {
+        if ($value === null) {
+            return $value;
+        }
+
+        return json_encode($value);
+    }
+}

--- a/src/Persister/LogTrait.php
+++ b/src/Persister/LogTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AuditStash\Persister;
+
+use Cake\Datasource\EntityInterface;
+use Cake\Error\Debugger;
+use Cake\Log\LogTrait as BaseLogTrait;
+
+trait LogTrait
+{
+    use BaseLogTrait;
+
+    /**
+     * Converts an entity to an error log message.
+     *
+     * @param \Cake\Datasource\EntityInterface $entity The entity to convert.
+     * @param int $depth The depth up to which to export the entity data.
+     * @return string
+     */
+    protected function toErrorLog(EntityInterface $entity, $depth = 4)
+    {
+        return sprintf(
+            '[%s] Persisting audit log failed. Data:' . PHP_EOL  . '%s',
+            __CLASS__,
+            Debugger::exportVar($entity, $depth)
+        );
+    }
+}

--- a/src/Persister/TablePersister.php
+++ b/src/Persister/TablePersister.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace AuditStash\Persister;
+
+use AuditStash\PersisterInterface;
+use Cake\Core\InstanceConfigTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Table;
+
+/**
+ * A persister that uses the ORM API to persist audit logs.
+ */
+class TablePersister implements PersisterInterface
+{
+    use ExtractionTrait;
+    use InstanceConfigTrait;
+    use LocatorAwareTrait;
+    use LogTrait;
+
+    /**
+     * Strategy that will choose between raw and serialized.
+     *
+     * @var string
+     */
+    const STRATEGY_AUTOMATIC = 'automatic';
+
+    /**
+     * Strategy that extracts data as separate fields/properties.
+     *
+     * @var string
+     */
+    const STRATEGY_PROPERTIES = 'properties';
+
+    /**
+     * Strategy that extracts data as is.
+     *
+     * @var string
+     */
+    const STRATEGY_RAW = 'raw';
+
+    /**
+     * Strategy that extracts data serialized in JSON format.
+     *
+     * @var string
+     */
+    const STRATEGY_SERIALIZED = 'serialized';
+
+    /**
+     * The default configuration.
+     *
+     * ## Configuration options
+     *
+     * - `extractMetaFields` (`bool|array`, defaults to `false`)
+     *
+     *   Defines whether/which meta data fields to extract as entity properties, thus
+     *   making them savable in the target table. When set to `true`, all meta data fields
+     *   being extracted, where the keys are being used as the property/column names.
+     *
+     *   When passing an array, either a `key => value` map, or single string values are
+     *   expected, where the key will be used as the property/column named, and the value
+     *   should be a `Hash::get()` compatible path that is used to extract from the meta
+     *   data. When passing single values, the value will be used as the property/name
+     *   as well as the path for extracting.
+     *
+     * - `logErrors` (`bool`, defaults to `true`)
+     *
+     *   Defines whether to log errors. By default, errors are logged using the log level
+     *   `LogLevel::ERROR`.
+     *
+     * - `primaryKeyExtractionStrategy` (`string`, defaults to `TablePersister::STRATEGY_AUTOMATIC`)
+     *
+     *   Defines how the primary key values of the changed records should be stored. Valid
+     *   values are the persister class' `STORAGE_STRATEGY_*` constants:
+     *
+     *     * `STRATEGY_AUTOMATIC`: Stores the primary key in a single column, either as is,
+     *        or in case of a composite key, in JSON format.
+     *
+     *     * `STRATEGY_PROPERTIES`: Stores the keys in individual columns if required.
+     *       Composite primary keys will be stored prefixed with `primary_key_` followed by the
+     *       index of the value in the primary key array.
+     *
+     *     * `STRATEGY_RAW`: Stores the key as is in a single column.
+     *
+     *     * `STRATEGY_SERIALIZED`: Stores the primary key in JSON format.
+     *
+     * - `serializeFields` (`bool`, defaults to `true`)
+     *
+     *   Defines whether the (non-primary key) fields that expect array data are being
+     *   serialized in JSON format.
+     *
+     * - `table` (`string|\Cake\ORM\Table`, defaults to `AuditLogs`)
+     *
+     *   Defines the table to use for persisting records. Either a string denoting a table
+     *   alias that is going to be resolved using the persisters table locator, or a table
+     *   object.
+     *
+     * - `unsetExtractedMetaFields` (`bool`, defaults to `true`)
+     *
+     *   Defines whether the fields extracted from the meta data should be unset, ie removed.
+     *
+     * @var array
+     */
+    protected $_defaultConfig = [
+        'extractMetaFields' => false,
+        'logErrors' => true,
+        'primaryKeyExtractionStrategy' => self::STRATEGY_AUTOMATIC,
+        'serializeFields' => true,
+        'table' => 'AuditLogs',
+        'unsetExtractedMetaFields' => true,
+    ];
+
+    /**
+     * The table to use for persisting logs.
+     *
+     * @var \Cake\ORM\Table
+     */
+    protected $_table;
+
+    /**
+     * Returns the table to use for persisting logs.
+     *
+     * @return \Cake\ORM\Table
+     */
+    public function getTable()
+    {
+        if ($this->_table === null) {
+            $this->setTable($this->config('table'));
+        }
+
+        return $this->_table;
+    }
+
+    /**
+     * Sets the table to use for persisting logs.
+     *
+     * @param string|\Cake\ORM\Table $table Either a string denoting a table alias, or a table object.
+     * @return $this
+     */
+    public function setTable($table)
+    {
+        if (is_string($table)) {
+            $table = $this->tableLocator()->get($table);
+        }
+
+        if (!($table instanceof Table)) {
+            throw new \InvalidArgumentException(
+                'The `$table` argument must be either a table alias, or an instance of `\Cake\ORM\Table`.'
+            );
+        }
+
+        $this->_table = $table;
+
+        return $this;
+    }
+
+    /**
+     * Persists each of the passed EventInterface objects.
+     *
+     * @param \AuditStash\EventInterface[] $auditLogs List of EventInterface objects to persist
+     * @return void
+     */
+    public function logEvents(array $auditLogs)
+    {
+        $PersisterTable = $this->getTable();
+
+        $serializeFields = $this->config('serializeFields');
+        $primaryKeyExtractionStrategy = $this->config('primaryKeyExtractionStrategy');
+        $extractMetaFields = $this->config('extractMetaFields');
+        $unsetExtractedMetaFields = $this->config('unsetExtractedMetaFields');
+        $logErrors = $this->config('logErrors');
+
+        foreach ($auditLogs as $log) {
+            $fields = $this->extractBasicFields($log, $serializeFields);
+            $fields += $this->extractPrimaryKeyFields($log, $primaryKeyExtractionStrategy);
+            $fields += $this->extractMetaFields(
+                $log, $extractMetaFields, $unsetExtractedMetaFields, $serializeFields
+            );
+
+            $persisterEntity = $PersisterTable->newEntity($fields);
+
+            if (!$PersisterTable->save($persisterEntity) &&
+                $logErrors
+            ) {
+                $this->log($this->toErrorLog($persisterEntity));
+            }
+        }
+    }
+}

--- a/src/Persister/TablePersister.php
+++ b/src/Persister/TablePersister.php
@@ -54,13 +54,23 @@ class TablePersister implements PersisterInterface
      *
      *   Defines whether/which meta data fields to extract as entity properties, thus
      *   making them savable in the target table. When set to `true`, all meta data fields
-     *   being extracted, where the keys are being used as the property/column names.
+     *   are being extracted, where the keys are being used as the property/column names.
      *
-     *   When passing an array, either a `key => value` map, or single string values are
-     *   expected, where the key will be used as the property/column named, and the value
-     *   should be a `Hash::get()` compatible path that is used to extract from the meta
-     *   data. When passing single values, the value will be used as the property/name
-     *   as well as the path for extracting.
+     *   When passing an array, a `key => value` map is expected, where the key should be
+     *   a `Hash::get()` compatible path that is used to extract from the meta data, and
+     *   the value will be used as the property/column named:
+     *
+     *   ```
+     *   [
+     *       'user.id' => 'user_id'
+     *   ]
+     *   ```
+     *
+     *   This would extract `['user']['id']` from the metadata array, and pass it as
+     *   a field named `user_id` to the entity to persist.
+     *
+     *   Alternatively a flat array with single string values can be passed, where the value
+     *   will be used as the property/name as well as the path for extracting.
      *
      * - `logErrors` (`bool`, defaults to `true`)
      *

--- a/src/config/Migrations/20171018185609_CreateAuditLogs.php
+++ b/src/config/Migrations/20171018185609_CreateAuditLogs.php
@@ -1,0 +1,102 @@
+<?php
+use Migrations\AbstractMigration;
+
+class CreateAuditLogs extends AbstractMigration
+{
+    public $autoId = false;
+
+    public function up()
+    {
+        $this->table('audit_logs')
+            ->addColumn('id', 'integer', [
+                'autoIncrement' => true,
+                'default' => null,
+                'limit' => 10,
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addPrimaryKey(['id'])
+            ->addColumn('transaction', 'uuid', [
+                'default' => null,
+                'limit' => null,
+                'null' => false,
+            ])
+            ->addColumn('type', 'string', [
+                'default' => null,
+                'limit' => 7,
+                'null' => false,
+            ])
+            ->addColumn('primary_key', 'integer', [
+                'default' => null,
+                'limit' => 10,
+                'null' => true,
+                'signed' => false,
+            ])
+            ->addColumn('source', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => false,
+            ])
+            ->addColumn('parent_source', 'string', [
+                'default' => null,
+                'limit' => 255,
+                'null' => true,
+            ])
+            ->addColumn('original', 'text', [
+                'default' => null,
+                'limit' => 16777215,
+                'null' => true,
+            ])
+            ->addColumn('changed', 'text', [
+                'default' => null,
+                'limit' => 16777215,
+                'null' => true,
+            ])
+            ->addColumn('meta', 'text', [
+                'default' => null,
+                'limit' => 16777215,
+                'null' => true,
+            ])
+            ->addColumn('created', 'datetime', [
+                'default' => null,
+                'limit' => null,
+                'null' => true,
+            ])
+            ->addIndex(
+                [
+                    'transaction',
+                ]
+            )
+            ->addIndex(
+                [
+                    'type',
+                ]
+            )
+            ->addIndex(
+                [
+                    'primary_key',
+                ]
+            )
+            ->addIndex(
+                [
+                    'source',
+                ]
+            )
+            ->addIndex(
+                [
+                    'parent_source',
+                ]
+            )
+            ->addIndex(
+                [
+                    'created',
+                ]
+            )
+            ->create();
+    }
+
+    public function down()
+    {
+        $this->dropTable('audit_logs');
+    }
+}

--- a/tests/TestCase/Persister/TablePersisterTest.php
+++ b/tests/TestCase/Persister/TablePersisterTest.php
@@ -1,0 +1,641 @@
+<?php
+
+namespace AuditStash\Test\Persister;
+
+use AuditStash\Event\AuditCreateEvent;
+use AuditStash\Persister\TablePersister;
+use Cake\Datasource\EntityInterface;
+use Cake\Error\Debugger;
+use Cake\ORM\Entity;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class AuditLogsTable extends Table
+{
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->table('audit_logs');
+        $this->primaryKey('id');
+
+        $this->schema([
+            'id' => 'integer',
+            'transaction' => 'string',
+            'type' => 'string',
+            'primary_key' => 'integer',
+            'source' => 'string',
+            'parent_source' => 'string',
+            'original' => 'string',
+            'changed' => 'string',
+            'meta' => 'string',
+            'created' => 'datetime',
+        ]);
+    }
+}
+
+class TablePersisterTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \AuditStash\Persister\TablePersister
+     */
+    public $TablePersister;
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->TablePersister = new TablePersister();
+
+        TableRegistry::config('AuditLogs', [
+            'className' => AuditLogsTable::class
+        ]);
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->TablePersister);
+
+        parent::tearDown();
+    }
+
+    public function testConfigDefaults()
+    {
+        $expected = [
+            'extractMetaFields' => false,
+            'logErrors' => true,
+            'primaryKeyExtractionStrategy' => TablePersister::STRATEGY_AUTOMATIC,
+            'serializeFields' => true,
+            'table' => 'AuditLogs',
+            'unsetExtractedMetaFields' => true,
+        ];
+        $this->assertEquals($expected, $this->TablePersister->config());
+    }
+
+    public function testGetTableDefault()
+    {
+        $this->assertInstanceOf(AuditLogsTable::class, $this->TablePersister->getTable());
+    }
+
+    public function testSetTableAsAlias()
+    {
+        $this->assertInstanceOf(AuditLogsTable::class, $this->TablePersister->getTable());
+        $this->assertInstanceOf(TablePersister::class, $this->TablePersister->setTable('Custom'));
+        $this->assertInstanceOf(Table::class, $this->TablePersister->getTable());
+        $this->assertEquals('Custom', $this->TablePersister->getTable()->alias());
+    }
+
+    public function testSetTableAsObject()
+    {
+        $customTable = TableRegistry::get('Custom');
+        $this->assertInstanceOf(AuditLogsTable::class, $this->TablePersister->getTable());
+        $this->assertInstanceOf(TablePersister::class, $this->TablePersister->setTable($customTable));
+        $this->assertSame($customTable, $this->TablePersister->getTable());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The `$table` argument must be either a table alias, or an instance of `\Cake\ORM\Table`.
+     */
+    public function testSetInvalidTable()
+    {
+        $this->TablePersister->setTable(null);
+    }
+
+    public function testSerializeNull()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', null, null);
+        $event->setMetaInfo(null);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => null,
+            'changed' => null,
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => null
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testExtractMetaFields()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+        $event->setMetaInfo([
+            'foo' => 'bar',
+            'baz' => [
+                'nested' => 'value',
+                'bar' => 'foo'
+            ]
+        ]);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => '{"baz":{"bar":"foo"}}',
+            'foo' => 'bar',
+            'nested' => 'value'
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $this->TablePersister->config([
+            'extractMetaFields' => [
+                'foo',
+                'baz.nested' => 'nested'
+            ]
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testExtractAllMetaFields()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+        $event->setMetaInfo([
+            'foo' => 'bar',
+            'baz' => [
+                'nested' => 'value',
+                'bar' => 'foo'
+            ]
+        ]);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => '[]',
+            'foo' => 'bar',
+            'baz' => [
+                'nested' => 'value',
+                'bar' => 'foo'
+            ]
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $this->TablePersister->config([
+            'extractMetaFields' => true
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testExtractMetaFieldsDoNotUnset()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+        $event->setMetaInfo([
+            'foo' => 'bar'
+        ]);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => '{"foo":"bar"}',
+            'foo' => 'bar'
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $this->TablePersister->config([
+            'extractMetaFields' => [
+                'foo'
+            ],
+            'unsetExtractedMetaFields' => false
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testExtractAllMetaFieldsDoNotUnset()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+        $event->setMetaInfo([
+            'foo' => 'bar'
+        ]);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => '{"foo":"bar"}',
+            'foo' => 'bar'
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $this->TablePersister->config([
+            'extractMetaFields' => true,
+            'unsetExtractedMetaFields' => false
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testErrorLogging()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+
+        /* @var $TablePersister TablePersister|\PHPUnit_Framework_MockObject_MockObject */
+        $TablePersister = $this
+            ->getMockBuilder(TablePersister::class)
+            ->setMethods(['log'])
+            ->getMock();
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => '[]'
+        ]);
+
+        $logged = clone $entity;
+        $logged->errors('field', ['error']);
+        $logged->source('AuditLogs');
+
+        $TablePersister
+            ->expects($this->once())
+            ->method('log')
+            ->with(
+                '[AuditStash\Persister\TablePersister] Persisting audit log failed. Data:' . PHP_EOL .
+                Debugger::exportVar($logged, 4)
+            );
+
+        $TablePersister->getTable()->eventManager()->on(
+            'Model.beforeSave',
+            function ($event, EntityInterface $entity) {
+                $entity->errors('field', ['error']);
+                return false;
+            }
+        );
+
+        $TablePersister->logEvents([$event]);
+    }
+
+    public function testDisableErrorLogging()
+    {
+        /* @var $TablePersister TablePersister|\PHPUnit_Framework_MockObject_MockObject */
+        $TablePersister = $this
+            ->getMockBuilder(TablePersister::class)
+            ->setMethods(['log'])
+            ->getMock();
+
+        $TablePersister
+            ->expects($this->never())
+            ->method('log');
+
+        $TablePersister->config([
+            'logErrors' => false
+        ]);
+        $TablePersister->getTable()->eventManager()->on(
+            'Model.beforeSave',
+            function ($event, EntityInterface $entity) {
+                return false;
+            }
+        );
+
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+        $TablePersister->logEvents([$event]);
+    }
+
+    public function testCompoundPrimaryKeyExtractDefault()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', [1, 2, 3], 'source', [], []);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => '[1,2,3]',
+            'meta' => '[]',
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $AuditLogsTable->schema()->columnType('primary_key', 'string');
+
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testPrimaryKeyExtractRaw()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => '[]',
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $this->TablePersister->config([
+            'primaryKeyExtractionStrategy' => TablePersister::STRATEGY_RAW
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testCompoundPrimaryKeyExtractRaw()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', [1, 2, 3], 'source', [], []);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => [1, 2, 3],
+            'meta' => '[]',
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $AuditLogsTable->schema()->columnType('primary_key', 'json');
+
+        $this->TablePersister->config([
+            'primaryKeyExtractionStrategy' => TablePersister::STRATEGY_RAW
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testPrimaryKeyExtractProperties()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => '[]',
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $this->TablePersister->config([
+            'primaryKeyExtractionStrategy' => TablePersister::STRATEGY_PROPERTIES
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testCompoundPrimaryKeyExtractProperties()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', [1, 2, 3], 'source', [], []);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key_0' => 1,
+            'primary_key_1' => 2,
+            'primary_key_2' => 3,
+            'meta' => '[]',
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $this->TablePersister->config([
+            'primaryKeyExtractionStrategy' => TablePersister::STRATEGY_PROPERTIES
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testPrimaryKeyExtractSerialized()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 'pk', 'source', [], []);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => '"pk"',
+            'meta' => '[]',
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $AuditLogsTable->schema()->columnType('primary_key', 'string');
+
+        $this->TablePersister->config([
+            'primaryKeyExtractionStrategy' => TablePersister::STRATEGY_SERIALIZED
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testCompoundPrimaryKeyExtractSerialized()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', [1, 2, 3], 'source', [], []);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => '[]',
+            'changed' => '[]',
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => '[1,2,3]',
+            'meta' => '[]',
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $AuditLogsTable->schema()->columnType('primary_key', 'string');
+
+        $this->TablePersister->config([
+            'primaryKeyExtractionStrategy' => TablePersister::STRATEGY_SERIALIZED
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+
+    public function testDoNotSerializeFields()
+    {
+        $event = new AuditCreateEvent('62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96', 1, 'source', [], []);
+        $event->setMetaInfo([
+            'foo' => 'bar'
+        ]);
+
+        $entity = new Entity([
+            'transaction' => '62ba2e1e-1524-4d4e-bb34-9bf0e03b6a96',
+            'type' => 'create',
+            'source' => 'source',
+            'parent_source' => null,
+            'original' => [],
+            'changed' => [],
+            'created' => new \DateTime($event->getTimestamp()),
+            'primary_key' => 1,
+            'meta' => [
+                'foo' => 'bar'
+            ],
+        ]);
+        $entity->source('AuditLogs');
+
+        $AuditLogsTable = $this->getMockForModel('AuditLogs', ['save'], TableRegistry::config('AuditLogs'));
+        $AuditLogsTable
+            ->expects($this->once())
+            ->method('save')
+            ->with($entity)
+            ->willReturn($entity);
+
+        $AuditLogsTable->schema()->columnType('original', 'json');
+        $AuditLogsTable->schema()->columnType('changed', 'json');
+        $AuditLogsTable->schema()->columnType('meta', 'json');
+
+        $this->TablePersister->config([
+            'serializeFields' => false
+        ]);
+        $this->TablePersister->setTable($AuditLogsTable);
+        $this->TablePersister->logEvents([$event]);
+    }
+}


### PR DESCRIPTION
This is pretty much a copy of the functionality as it lives in a plugin of mine that I regularily use. I've only made some slight changes for now to get the tests running, but it should be good enough to review whether it might be a useful additional.

As mentioned on Slack the other day, it can be configured with custom tables (and/or locators, which requires CakePHP >= 3.1), has basic error logging, can store primary keys in different formats (plain, multi-column, JSON), and can be configured to extract any metadata as properties/columns.

In its current state it's more or less compatible with the existing database persister (JSON encoding wont encode `null`, and by default no metadata is being extracted).