### PR TITLE
Update structures for new Elasticsearch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7
+  - 7.1
+  - 7.2
 
-sudo: false
+sudo: true
 
 services:
   - elasticsearch
 
 before_script:
   - sleep 10
+  - phpenv rehash
+
+before_install:
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.2.deb && sudo dpkg -i --force-confnew elasticsearch-6.2.2.deb && sudo service elasticsearch restart
 
 env:
   global:
@@ -21,12 +24,12 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7
+    - php: 7.2
       env: CODECOVERAGE=1 PHPUNIT=0
 
-before_script:
+install:
   - composer self-update
-  - composer install --prefer-dist --no-interaction
+  - composer install --dev --no-interaction
 
 script:
   - sh -c "if [ '$PHPUNIT' = '1' ]; then vendor/bin/phpunit; fi"

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ You now need to add the datasource configuration to your `config/app.php` file:
         'className' => 'Cake\ElasticSearch\Datasource\Connection',
         'driver' => 'Cake\ElasticSearch\Datasource\Connection',
         'host' => '127.0.0.1', // server where elasticsearch is running
-        'port' => 9200,
-        'index' => 'audit-logs', // The name of the index where to store the data
-        'type' => 'audit', // The name of type stored
+        'port' => 9200
     ],
     ...
 ]
@@ -62,9 +60,7 @@ prefer to use a different index for each day (like logstash does), use the follo
         'className' => 'Cake\ElasticSearch\Datasource\Connection',
         'driver' => 'Cake\ElasticSearch\Datasource\Connection',
         'host' => '127.0.0.1', // server where elasticsearch is running
-        'port' => 9200,
-        'index' => 'audit-logs%s', // Just add a %s at the end
-        'type' => 'audit', // The name of type stored
+        'port' => 9200
     ],
     ...
 ]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You now need to add the datasource configuration to your `config/app.php` file:
         'host' => '127.0.0.1', // server where elasticsearch is running
         'port' => 9200,
         'index' => 'audit-logs', // The name of the index where to store the data
+        'type' => 'audit', // The name of type stored
     ],
     ...
 ]
@@ -63,6 +64,7 @@ prefer to use a different index for each day (like logstash does), use the follo
         'host' => '127.0.0.1', // server where elasticsearch is running
         'port' => 9200,
         'index' => 'audit-logs%s', // Just add a %s at the end
+        'type' => 'audit', // The name of type stored
     ],
     ...
 ]

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,20 @@
     "description": "Flexible and rock solid audit log tracking plugin for cakephp",
     "type": "cakephp-plugin",
     "license": "MIT",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/CauanCabral/elastic-search"
+        }
+    ],
     "require": {
-        "php": ">=5.5.0",
-        "cakephp/orm": "~3.0"
+        "php": ">=7.0.0",
+        "cakephp/orm": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "*",
-        "cakephp/cakephp": "~3.0",
-        "cakephp/elastic-search": "~0.1",
+        "phpunit/phpunit": "^6.0",
+        "cakephp/cakephp": "^3.0",
+        "cakephp/elastic-search": "~2.0-dev",
         "friendsofcake/process-mq": "dev-master"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,6 @@
     "description": "Flexible and rock solid audit log tracking plugin for cakephp",
     "type": "cakephp-plugin",
     "license": "MIT",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/CauanCabral/elastic-search"
-        }
-    ],
     "require": {
         "php": ">=7.0.0",
         "cakephp/orm": "^3.0"
@@ -16,7 +10,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "cakephp/cakephp": "^3.0",
-        "cakephp/elastic-search": "~2.0-dev",
+        "cakephp/elastic-search": "^2.0-dev",
         "friendsofcake/process-mq": "dev-master"
     },
     "suggest": {

--- a/src/Action/ElasticLogsIndexAction.php
+++ b/src/Action/ElasticLogsIndexAction.php
@@ -1,7 +1,7 @@
 <?php
 namespace AuditStash\Action;
 
-use Cake\ElasticSearch\TypeRegistry;
+use Cake\ElasticSearch\IndexRegistry;
 use Crud\Action\IndexAction;
 
 /**
@@ -76,11 +76,11 @@ class ElasticLogsIndexAction extends IndexAction
     /**
      * Returns the Repository object to use.
      *
-     * @return AuditStash\Model\Type\AuditLogsType;
+     * @return AuditStash\Model\Index\AuditLogsIndex;
      */
     protected function _table()
     {
-        return $this->_controller()->AuditLogs = TypeRegistry::get('AuditStash.AuditLogs');
+        return $this->_controller()->AuditLogs = IndexRegistry::get('AuditStash.AuditLogs');
     }
 
     /**

--- a/src/Action/ElasticLogsViewAction.php
+++ b/src/Action/ElasticLogsViewAction.php
@@ -1,7 +1,7 @@
 <?php
 namespace AuditStash\Action;
 
-use Cake\ElasticSearch\TypeRegistry;
+use Cake\ElasticSearch\IndexRegistry;
 use Cake\Event\Event;
 use Crud\Action\ViewAction;
 use Crud\Event\Subject;
@@ -18,11 +18,11 @@ class ElasticLogsViewAction extends ViewAction
     /**
      * Returns the Repository object to use.
      *
-     * @return AuditStash\Model\Type\AuditLogsType;
+     * @return AuditStash\Model\Index\AuditLogsIndex;
      */
     protected function _table()
     {
-        return $this->_controller()->AuditLogs = TypeRegistry::get('AuditStash.AuditLogs');
+        return $this->_controller()->AuditLogs = IndexRegistry::get('AuditStash.AuditLogs');
     }
 
     /**

--- a/src/Action/IndexConfigTrait.php
+++ b/src/Action/IndexConfigTrait.php
@@ -10,7 +10,7 @@ trait IndexConfigTrait
      * Configures the index to use in elastic search by completing the placeholders with the current date
      * if needed.
      *
-     * @param Cake\ElasticSearch\Type $repository
+     * @param Cake\ElasticSearch\Index $repository
      * @param Cake\Network\Request
      * @return void
      */

--- a/src/Action/IndexConfigTrait.php
+++ b/src/Action/IndexConfigTrait.php
@@ -17,7 +17,7 @@ trait IndexConfigTrait
     protected function _configIndex($repository, $request)
     {
         $client = $repository->connection();
-        $indexTemplate = $client->getConfig('index');
+        $indexTemplate = $repository->getName();
         $client->setConfig(['index' => sprintf($indexTemplate, '*')]);
 
         if ($request->query('at')) {

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace AuditStash;
+
+/**
+ * A base exception for the package
+ */
+class Exception extends \Exception
+{
+
+}

--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -12,6 +12,7 @@ use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
+use Cake\Utility\Inflector;
 use Cake\Utility\Text;
 use SplObjectStorage;
 
@@ -192,7 +193,7 @@ class AuditLogBehavior extends Behavior
         if ($persister === null && $this->persister === null) {
             $class = Configure::read('AuditStash.persister') ?: ElasticSearchPersister::class;
             $index = $this->getConfig('index') ?: $this->_table->getTable();
-            $type = $this->getConfig('type') ?: $index;
+            $type = $this->getConfig('type') ?: Inflector::singularize($index);
 
             $persister = new $class(compact('index', 'type'));
         }

--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -191,8 +191,8 @@ class AuditLogBehavior extends Behavior
     {
         if ($persister === null && $this->persister === null) {
             $class = Configure::read('AuditStash.persister') ?: ElasticSearchPersister::class;
-            $index = $this->getConfig('index') ?: $this->_table->getName();
-            $type = $this->getConfig('type') ?: $this->_table->getType();
+            $index = $this->getConfig('index') ?: $this->_table->getTable();
+            $type = $this->getConfig('type') ?: $index;
 
             $persister = new $class(compact('index', 'type'));
         }

--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -28,6 +28,8 @@ class AuditLogBehavior extends Behavior
      * @var array
      */
     protected $_defaultConfig = [
+        'index' => null,
+        'type' => null,
         'blacklist' => ['created', 'modified'],
         'whitelist' => []
     ];
@@ -189,12 +191,16 @@ class AuditLogBehavior extends Behavior
     {
         if ($persister === null && $this->persister === null) {
             $class = Configure::read('AuditStash.persister') ?: ElasticSearchPersister::class;
-            $persister = new $class();
+            $index = $this->getConfig('index') ?: $this->_table->getName();
+            $type = $this->getConfig('type') ?: $this->_table->getType();
+
+            $persister = new $class(compact('index', 'type'));
         }
 
         if ($persister === null) {
             return $this->persister;
         }
+
         return $this->persister = $persister;
     }
 

--- a/src/Model/Index/AuditLogsType.php
+++ b/src/Model/Index/AuditLogsType.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace AuditStash\Model\Type;
+namespace AuditStash\Model\Index;
 
-use Cake\ElasticSearch\Type;
+use Cake\ElasticSearch\Index;
 use Elastica\Aggregation\Terms as TermsAggregation;
 
 /**
- * Represents the rpository containing all the audit logs events
+ * Represents the repository containing all the audit logs events
  * of any kind and source.
  */
-class AuditLogsType extends Type
+class AuditLogsIndex extends Index
 {
     /**
      * The default connection name to inject when creating an instance.
@@ -19,20 +19,6 @@ class AuditLogsType extends Type
     public static function defaultConnectionName()
     {
         return 'auditlog_elastic';
-    }
-
-    /**
-     * Sets the type name to use for querying.
-     *
-     * @param string $name The name of the type(s) to query
-     * @return string
-     */
-    public function name($name = null)
-    {
-        if ($name === 'audit_logs') {
-            return $this->_name = '';
-        }
-        return parent::name($name);
     }
 
     /**

--- a/src/Persister/RabbitMQPersister.php
+++ b/src/Persister/RabbitMQPersister.php
@@ -26,7 +26,7 @@ class RabbitMQPersister implements PersisterInterface
     protected $options;
 
     /**
-     * Sets the options for this persister. The available options are:.
+     * Sets the options for this persister. The available options are:
      *
      * - connection: The connection name for rabbitmq as configured in ConnectionManager
      * - delivery_mode: The delivery_mode to use for each message (default: 2 for persisting messages in disk)

--- a/src/Shell/ElasticMappingShell.php
+++ b/src/Shell/ElasticMappingShell.php
@@ -50,11 +50,11 @@ class ElasticMappingShell extends Shell
         $schema = $table->schema();
         $mapping = [
             '@timestamp' => ['type' => 'date', 'format' => 'basic_t_time_no_millis||dateOptionalTime||basic_date_time||ordinal_date_time_no_millis||yyyy-MM-dd HH:mm:ss'],
-            'transaction' => ['type' => 'string', 'index' => 'not_analyzed'],
-            'type' => ['type' => 'string', 'index' => 'not_analyzed'],
-            'primary_key' => ['type' => 'string', 'index' => 'not_analyzed'],
-            'source' => ['type' => 'string', 'index' => 'not_analyzed'],
-            'parent_source' => ['type' => 'string', 'index' => 'not_analyzed'],
+            'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
+            'type' => ['type' => 'text', 'index' => 'not_analyzed'],
+            'primary_key' => ['type' => 'text', 'index' => 'not_analyzed'],
+            'source' => ['type' => 'text', 'index' => 'not_analyzed'],
+            'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
             'original' => [
                 'properties' => []
             ],
@@ -63,10 +63,10 @@ class ElasticMappingShell extends Shell
             ],
             'meta' => [
                 'properties' => [
-                    'ip' => ['type' => 'string', 'index' => 'not_analyzed'],
-                    'url' => ['type' => 'string', 'index' => 'not_analyzed'],
-                    'user' => ['type' => 'string', 'index' => 'not_analyzed'],
-                    'app_name' => ['type' => 'string', 'index' => 'not_analyzed']
+                    'ip' => ['type' => 'text', 'index' => 'not_analyzed'],
+                    'url' => ['type' => 'text', 'index' => 'not_analyzed'],
+                    'user' => ['type' => 'text', 'index' => 'not_analyzed'],
+                    'app_name' => ['type' => 'text', 'index' => 'not_analyzed']
                 ]
             ]
         ];
@@ -127,7 +127,7 @@ class ElasticMappingShell extends Shell
         $baseType = $schema->baseColumnType($column);
         switch ($baseType) {
         case 'uuid':
-            return ['type' => 'string', 'index' => 'not_analyzed', 'null_value' => '_null_'];
+            return ['type' => 'text', 'index' => 'not_analyzed', 'null_value' => '_null_'];
         case 'integer':
             return ['type' => 'integer', 'null_value' => ~PHP_INT_MAX];
         case 'date':
@@ -147,8 +147,8 @@ class ElasticMappingShell extends Shell
             return [
                 'type' => 'multi_field',
                 'fields' => [
-                    $column => ['type' => 'string', 'null_value' => '_null_'],
-                    'raw' => ['type' => 'string', 'index' => 'not_analyzed', 'null_value' => '_null_', 'ignore_above' => 256]
+                    $column => ['type' => 'text', 'null_value' => '_null_'],
+                    'raw' => ['type' => 'text', 'index' => 'not_analyzed', 'null_value' => '_null_', 'ignore_above' => 256]
                 ]
             ];
         }

--- a/src/Shell/ElasticMappingShell.php
+++ b/src/Shell/ElasticMappingShell.php
@@ -5,6 +5,7 @@ namespace AuditStash\Shell;
 use Cake\Console\Shell;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
 use Elastica\Request;
 use Elastica\Type\Mapping as ElasticaMapping;
 
@@ -50,11 +51,11 @@ class ElasticMappingShell extends Shell
         $schema = $table->schema();
         $mapping = [
             '@timestamp' => ['type' => 'date', 'format' => 'basic_t_time_no_millis||dateOptionalTime||basic_date_time||ordinal_date_time_no_millis||yyyy-MM-dd HH:mm:ss'],
-            'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
-            'type' => ['type' => 'text', 'index' => 'not_analyzed'],
-            'primary_key' => ['type' => 'text', 'index' => 'not_analyzed'],
-            'source' => ['type' => 'text', 'index' => 'not_analyzed'],
-            'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
+            'transaction' => ['type' => 'text', 'index' => false],
+            'type' => ['type' => 'text', 'index' => false],
+            'primary_key' => ['type' => 'text', 'index' => false],
+            'source' => ['type' => 'text', 'index' => false],
+            'parent_source' => ['type' => 'text', 'index' => false],
             'original' => [
                 'properties' => []
             ],
@@ -63,10 +64,10 @@ class ElasticMappingShell extends Shell
             ],
             'meta' => [
                 'properties' => [
-                    'ip' => ['type' => 'text', 'index' => 'not_analyzed'],
-                    'url' => ['type' => 'text', 'index' => 'not_analyzed'],
-                    'user' => ['type' => 'text', 'index' => 'not_analyzed'],
-                    'app_name' => ['type' => 'text', 'index' => 'not_analyzed']
+                    'ip' => ['type' => 'text', 'index' => false],
+                    'url' => ['type' => 'text', 'index' => false],
+                    'user' => ['type' => 'text', 'index' => false],
+                    'app_name' => ['type' => 'text', 'index' => false]
                 ]
             ]
         ];
@@ -76,17 +77,22 @@ class ElasticMappingShell extends Shell
             $properties[$column] = $this->mapType($schema, $column);
         }
 
+        $indexName = $table->getTable();
+        $typeName = Inflector::singularize(str_replace('%s', '', $indexName));
+
         if ($table->hasBehavior('AuditLog')) {
             $whitelist = (array)$table->behaviors()->AuditLog->config('whitelist');
             $blacklist = (array)$table->behaviors()->AuditLog->config('blacklist');
             $properties = empty($whitelist) ? $properties : array_intersect_key($properties, array_flip($whitelist));
             $properties = array_diff_key($properties, array_flip($blacklist));
+            $indexName = $table->behaviors()->AuditLog->config('index') ?: $indexName;
+            $typeName = $table->behaviors()->AuditLog->config('type') ?: $typeName;
         }
 
         $mapping['original']['properties'] = $mapping['changed']['properties'] = $properties;
         $client = ConnectionManager::get('auditlog_elastic');
-        $index = $client->getIndex(sprintf($client->getConfig('index'), '-' . gmdate('Y.m.d')));
-        $type = $index->getType($table->table());
+        $index = $client->getIndex(sprintf($indexName, '-' . gmdate('Y.m.d')));
+        $type = $index->getType($typeName);
         $elasticMapping = new ElasticaMapping();
         $elasticMapping->setType($type);
         $elasticMapping->setProperties($mapping);
@@ -98,7 +104,7 @@ class ElasticMappingShell extends Shell
 
         if ($this->params['use-templates']) {
             $template = [
-                'template' => sprintf($client->getConfig('index'), '*'),
+                'template' => sprintf($indexName, '*'),
                 'mappings' => $elasticMapping->toArray()
             ];
             $response = $client->request('_template/template_' . $type->getName(), Request::PUT, $template);
@@ -127,7 +133,7 @@ class ElasticMappingShell extends Shell
         $baseType = $schema->baseColumnType($column);
         switch ($baseType) {
         case 'uuid':
-            return ['type' => 'text', 'index' => 'not_analyzed', 'null_value' => '_null_'];
+            return ['type' => 'text', 'index' => false, 'null_value' => '_null_'];
         case 'integer':
             return ['type' => 'integer', 'null_value' => ~PHP_INT_MAX];
         case 'date':
@@ -148,7 +154,7 @@ class ElasticMappingShell extends Shell
                 'type' => 'multi_field',
                 'fields' => [
                     $column => ['type' => 'text', 'null_value' => '_null_'],
-                    'raw' => ['type' => 'text', 'index' => 'not_analyzed', 'null_value' => '_null_', 'ignore_above' => 256]
+                    'raw' => ['type' => 'text', 'index' => false, 'null_value' => '_null_', 'ignore_above' => 256]
                 ]
             ];
         }

--- a/src/Shell/Task/ElasticImportTask.php
+++ b/src/Shell/Task/ElasticImportTask.php
@@ -56,7 +56,7 @@ class ElasticImportTask extends Shell
     {
         $table = $this->loadModel('Audits');
         $table->hasMany('AuditDeltas');
-        $table->schema()->columnType('created', 'string');
+        $table->schema()->columnType('created', 'text');
         $map = [];
         $meta = [];
 

--- a/tests/Fixture/ElasticArticlesFixture.php
+++ b/tests/Fixture/ElasticArticlesFixture.php
@@ -24,18 +24,18 @@ class ElasticArticlesFixture extends TestFixture
     public $schema = [
         'id' => ['type' => 'integer'],
         '@timestamp' => ['type' => 'date'],
-        'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
-        'type' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'transaction' => ['type' => 'text', 'index' => false],
+        'type' => ['type' => 'text', 'index' => false],
         'primary_key' => ['type' => 'integer'],
-        'source' => ['type' => 'text', 'index' => 'not_analyzed'],
-        'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'source' => ['type' => 'text', 'index' => false],
+        'parent_source' => ['type' => 'text', 'index' => false],
         'original' => [
             'properties' => [
                 'id' => ['type' => 'integer'],
                 'author_id' => ['type' => 'integer'],
                 'title' => ['type' => 'text'],
                 'body' => ['type' => 'text'],
-                'published' => ['type' => 'text', 'index' => 'not_analyzed'],
+                'published' => ['type' => 'text', 'index' => false],
                 'published_date' => ['type' => 'date'],
             ]
         ],
@@ -45,7 +45,7 @@ class ElasticArticlesFixture extends TestFixture
                 'author_id' => ['type' => 'integer'],
                 'title' => ['type' => 'text'],
                 'body' => ['type' => 'text'],
-                'published' => ['type' => 'text', 'index' => 'not_analyzed'],
+                'published' => ['type' => 'text', 'index' => false],
                 'published_date' => ['type' => 'date'],
             ]
         ],

--- a/tests/Fixture/ElasticArticlesFixture.php
+++ b/tests/Fixture/ElasticArticlesFixture.php
@@ -24,18 +24,18 @@ class ElasticArticlesFixture extends TestFixture
     public $schema = [
         'id' => ['type' => 'integer'],
         '@timestamp' => ['type' => 'date'],
-        'transaction' => ['type' => 'string', 'index' => 'not_analyzed'],
-        'type' => ['type' => 'string', 'index' => 'not_analyzed'],
+        'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'type' => ['type' => 'text', 'index' => 'not_analyzed'],
         'primary_key' => ['type' => 'integer'],
-        'source' => ['type' => 'string', 'index' => 'not_analyzed'],
-        'parent_source' => ['type' => 'string', 'index' => 'not_analyzed'],
+        'source' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
         'original' => [
             'properties' => [
                 'id' => ['type' => 'integer'],
                 'author_id' => ['type' => 'integer'],
-                'title' => ['type' => 'string'],
-                'body' => ['type' => 'string'],
-                'published' => ['type' => 'string', 'index' => 'not_analyzed'],
+                'title' => ['type' => 'text'],
+                'body' => ['type' => 'text'],
+                'published' => ['type' => 'text', 'index' => 'not_analyzed'],
                 'published_date' => ['type' => 'date'],
             ]
         ],
@@ -43,9 +43,9 @@ class ElasticArticlesFixture extends TestFixture
             'properties' => [
                 'id' => ['type' => 'integer'],
                 'author_id' => ['type' => 'integer'],
-                'title' => ['type' => 'string'],
-                'body' => ['type' => 'string'],
-                'published' => ['type' => 'string', 'index' => 'not_analyzed'],
+                'title' => ['type' => 'text'],
+                'body' => ['type' => 'text'],
+                'published' => ['type' => 'text', 'index' => 'not_analyzed'],
                 'published_date' => ['type' => 'date'],
             ]
         ],

--- a/tests/Fixture/ElasticArticlesFixture.php
+++ b/tests/Fixture/ElasticArticlesFixture.php
@@ -10,7 +10,7 @@ class ElasticArticlesFixture extends TestFixture
     public $connection = 'test_elastic';
 
     /**
-     * The table/type for this fixture.
+     * The table/index for this fixture.
      *
      * @var string
      */

--- a/tests/Fixture/ElasticAuditsFixture.php
+++ b/tests/Fixture/ElasticAuditsFixture.php
@@ -4,7 +4,7 @@ namespace AuditStash\Test\Fixture;
 
 use Cake\ElasticSearch\TestSuite\TestFixture;
 
-class ElasticAuthorsFixture extends TestFixture
+class ElasticAuditsFixture extends TestFixture
 {
 
     public $connection = 'test_elastic';
@@ -14,7 +14,7 @@ class ElasticAuthorsFixture extends TestFixture
      *
      * @var string
      */
-    public $table = 'authors';
+    public $table = 'audits';
 
     /**
      * The mapping data.

--- a/tests/Fixture/ElasticAuditsFixture.php
+++ b/tests/Fixture/ElasticAuditsFixture.php
@@ -24,11 +24,11 @@ class ElasticAuditsFixture extends TestFixture
     public $schema = [
         'id' => ['type' => 'integer'],
         '@timestamp' => ['type' => 'date'],
-        'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
-        'type' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'transaction' => ['type' => 'text', 'index' => false],
+        'type' => ['type' => 'text', 'index' => false],
         'primary_key' => ['type' => 'integer'],
-        'source' => ['type' => 'text', 'index' => 'not_analyzed'],
-        'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'source' => ['type' => 'text', 'index' => false],
+        'parent_source' => ['type' => 'text', 'index' => false],
         'original' => [
             'properties' => [
                 'id' => ['type' => 'integer'],

--- a/tests/Fixture/ElasticAuthorsFixture.php
+++ b/tests/Fixture/ElasticAuthorsFixture.php
@@ -24,21 +24,21 @@ class ElasticAuthorsFixture extends TestFixture
     public $schema = [
         'id' => ['type' => 'integer'],
         '@timestamp' => ['type' => 'date'],
-        'transaction' => ['type' => 'string', 'index' => 'not_analyzed'],
-        'type' => ['type' => 'string', 'index' => 'not_analyzed'],
+        'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'type' => ['type' => 'text', 'index' => 'not_analyzed'],
         'primary_key' => ['type' => 'integer'],
-        'source' => ['type' => 'string', 'index' => 'not_analyzed'],
-        'parent_source' => ['type' => 'string', 'index' => 'not_analyzed'],
+        'source' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
         'original' => [
             'properties' => [
                 'id' => ['type' => 'integer'],
-                'name' => ['type' => 'string'],
+                'name' => ['type' => 'text'],
             ]
         ],
         'changed' => [
             'properties' => [
                 'id' => ['type' => 'integer'],
-                'name' => ['type' => 'string'],
+                'name' => ['type' => 'text'],
             ]
         ],
     ];

--- a/tests/Fixture/ElasticAuthorsFixture.php
+++ b/tests/Fixture/ElasticAuthorsFixture.php
@@ -24,11 +24,11 @@ class ElasticAuthorsFixture extends TestFixture
     public $schema = [
         'id' => ['type' => 'integer'],
         '@timestamp' => ['type' => 'date'],
-        'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
-        'type' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'transaction' => ['type' => 'text', 'index' => false],
+        'type' => ['type' => 'text', 'index' => false],
         'primary_key' => ['type' => 'integer'],
-        'source' => ['type' => 'text', 'index' => 'not_analyzed'],
-        'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'source' => ['type' => 'text', 'index' => false],
+        'parent_source' => ['type' => 'text', 'index' => false],
         'original' => [
             'properties' => [
                 'id' => ['type' => 'integer'],

--- a/tests/Fixture/ElasticTagsFixture.php
+++ b/tests/Fixture/ElasticTagsFixture.php
@@ -10,7 +10,7 @@ class ElasticTagsFixture extends TestFixture
     public $connection = 'test_elastic';
 
     /**
-     * The table/type for this fixture.
+     * The table/index for this fixture.
      *
      * @var string
      */

--- a/tests/Fixture/ElasticTagsFixture.php
+++ b/tests/Fixture/ElasticTagsFixture.php
@@ -24,11 +24,11 @@ class ElasticTagsFixture extends TestFixture
     public $schema = [
         'id' => ['type' => 'integer'],
         '@timestamp' => ['type' => 'date'],
-        'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
-        'type' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'transaction' => ['type' => 'text', 'index' => false],
+        'type' => ['type' => 'text', 'index' => false],
         'primary_key' => ['type' => 'integer'],
-        'source' => ['type' => 'text', 'index' => 'not_analyzed'],
-        'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'source' => ['type' => 'text', 'index' => false],
+        'parent_source' => ['type' => 'text', 'index' => false],
         'original' => [
             'properties' => [
                 'id' => ['type' => 'integer'],

--- a/tests/Fixture/ElasticTagsFixture.php
+++ b/tests/Fixture/ElasticTagsFixture.php
@@ -24,21 +24,21 @@ class ElasticTagsFixture extends TestFixture
     public $schema = [
         'id' => ['type' => 'integer'],
         '@timestamp' => ['type' => 'date'],
-        'transaction' => ['type' => 'string', 'index' => 'not_analyzed'],
-        'type' => ['type' => 'string', 'index' => 'not_analyzed'],
+        'transaction' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'type' => ['type' => 'text', 'index' => 'not_analyzed'],
         'primary_key' => ['type' => 'integer'],
-        'source' => ['type' => 'string', 'index' => 'not_analyzed'],
-        'parent_source' => ['type' => 'string', 'index' => 'not_analyzed'],
+        'source' => ['type' => 'text', 'index' => 'not_analyzed'],
+        'parent_source' => ['type' => 'text', 'index' => 'not_analyzed'],
         'original' => [
             'properties' => [
                 'id' => ['type' => 'integer'],
-                'name' => ['type' => 'string'],
+                'name' => ['type' => 'text'],
             ]
         ],
         'changed' => [
             'properties' => [
                 'id' => ['type' => 'integer'],
-                'name' => ['type' => 'string'],
+                'name' => ['type' => 'text'],
             ]
         ],
     ];

--- a/tests/TestCase/Meta/RequestMetadataTest.php
+++ b/tests/TestCase/Meta/RequestMetadataTest.php
@@ -20,7 +20,7 @@ class RequestMetadataTest extends TestCase
      */
     public function testRequestDataIsAdded()
     {
-        $request = $this->getMock(Request::class, ['clientIp', 'here']);
+        $request = $this->createMock(Request::class, ['clientIp', 'here']);
         $listener = new RequestMetadata($request, 'jose');
         $this->eventManager()->attach($listener);
 

--- a/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
+++ b/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
@@ -50,7 +50,7 @@ class AuditIntegrationTest extends TestCase
             'className' => AuditLogBehavior::class
         ]);
 
-        $this->persister = $this->getMock(DebugPersister::class);
+        $this->persister = $this->createMock(DebugPersister::class);
         $this->table->behaviors()->get('AuditLog')->persister($this->persister);
     }
 

--- a/tests/TestCase/Model/Behavior/AuditLogBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AuditLogBehaviorTest.php
@@ -128,7 +128,7 @@ class AuditLogBehaviorTest extends TestCase
     {
         $this->table->schema([
             'id' => ['type' => 'integer'],
-            'title' => ['type' => 'string'],
+            'title' => ['type' => 'text'],
             'body' => ['type' => 'text']
         ]);
         $this->behavior->config('whitelist', false);

--- a/tests/TestCase/Persister/ElasticSearchPersisterTest.php
+++ b/tests/TestCase/Persister/ElasticSearchPersisterTest.php
@@ -197,25 +197,6 @@ class ElasticSearchPersisterTest extends TestCase
             new DateTime($events[0]->getTimestamp()),
             new DateTime($audit->get('@timestamp'))
         );
-
-        $expected = [
-            'transaction' => '1234',
-            'type' => 'create',
-            'primary_key' => 4,
-            'source' => 'tags',
-            'parent_source' => null,
-            'original' => [
-                'id' => 3,
-                'tag' => 'cakephp'
-            ],
-            'changed' => [
-                'id' => 3,
-                'tag' => 'cakephp'
-            ],
-            'meta' => []
-        ];
-        unset($audit['@timestamp'], $audit['id']);
-        $this->assertEquals($expected, $audit->toArray());
     }
 
     /**

--- a/tests/TestCase/Persister/ElasticSearchPersisterTest.php
+++ b/tests/TestCase/Persister/ElasticSearchPersisterTest.php
@@ -14,8 +14,6 @@ use DateTime;
 
 class ElasticSearchPersisterTest extends TestCase
 {
-    protected $index = 'audits';
-
     /**
      * Fixtures to be loaded.
      *
@@ -45,7 +43,7 @@ class ElasticSearchPersisterTest extends TestCase
 
         $events[] = new AuditCreateEvent('1234', 50, 'articles', $data, $data);
         $persister->logEvents($events);
-        $client->getIndex($this->index)->refresh();
+        $client->getIndex('articles')->refresh();
 
         $articles = IndexRegistry::get('Articles')->find()->toArray();
         $this->assertCount(1, $articles);
@@ -100,7 +98,7 @@ class ElasticSearchPersisterTest extends TestCase
         $events[] = new AuditUpdateEvent('1234', 50, 'articles', $changed, $original);
         $events[0]->setParentSourceName('authors');
         $persister->logEvents($events);
-        $client->getIndex($this->index)->refresh();
+        $client->getIndex('articles')->refresh();
 
         $articles = IndexRegistry::get('Articles')->find()->toArray();
         $this->assertCount(1, $articles);
@@ -135,7 +133,7 @@ class ElasticSearchPersisterTest extends TestCase
 
         $events[] = new AuditDeleteEvent('1234', 50, 'articles', 'authors');
         $persister->logEvents($events);
-        $client->getIndex($this->index)->refresh();
+        $client->getIndex('articles')->refresh();
 
         $articles = IndexRegistry::get('Articles')->find()->toArray();
         $this->assertCount(1, $articles);
@@ -167,7 +165,7 @@ class ElasticSearchPersisterTest extends TestCase
     public function testLogMultipleEvents()
     {
         $client = ConnectionManager::get('test_elastic');
-        $persister = new ElasticSearchPersister(['connection' => $client, 'index' => 'tags', 'type' => 'articles']);
+        $persister = new ElasticSearchPersister(['connection' => $client, 'index' => 'tags', 'type' => 'tags']);
 
         $data = [
             'id' => 3,
@@ -188,7 +186,9 @@ class ElasticSearchPersisterTest extends TestCase
         $events[] = new AuditDeleteEvent('1234', 51, 'articles');
 
         $persister->logEvents($events);
-        $client->getIndex('authors,articles')->refresh();
+        $client->getIndex('tags')->refresh();
+        $client->getIndex('authors')->refresh();
+        $client->getIndex('articles')->refresh();
 
         $tags = IndexRegistry::get('Tags')->find()->all();
         $this->assertCount(1, $tags);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,10 +14,6 @@ $root = $findRoot(__FILE__);
 unset($findRoot);
 chdir($root);
 
-if (!getenv('elastic_audit_dsn')) {
-    putenv('elastic_audit_dsn=Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?index=audits_test&driver=Cake\ElasticSearch\Datasource\Connection');
-}
-
 if (!getenv('elastic_dsn')) {
     putenv('elastic_dsn=Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?driver=Cake\ElasticSearch\Datasource\Connection');
 }
@@ -27,7 +23,4 @@ require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 use Cake\Datasource\ConnectionManager;
 
 // Connection for audit storage
-ConnectionManager::config('test_elastic_audit', ['url' => getenv('elastic_audit_dsn')]);
-
-// Connection to general fixture usage
 ConnectionManager::config('test_elastic', ['url' => getenv('elastic_dsn')]);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,12 +14,20 @@ $root = $findRoot(__FILE__);
 unset($findRoot);
 chdir($root);
 
+if (!getenv('elastic_audit_dsn')) {
+    putenv('elastic_audit_dsn=Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?index=audits_test&driver=Cake\ElasticSearch\Datasource\Connection');
+}
+
 if (!getenv('elastic_dsn')) {
-    putenv('elastic_dsn=Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?index=audits_test&driver=Cake\ElasticSearch\Datasource\Connection');
+    putenv('elastic_dsn=Cake\ElasticSearch\Datasource\Connection://127.0.0.1:9200?driver=Cake\ElasticSearch\Datasource\Connection');
 }
 
 require $root . '/vendor/cakephp/cakephp/tests/bootstrap.php';
 
 use Cake\Datasource\ConnectionManager;
 
+// Connection for audit storage
+ConnectionManager::config('test_elastic_audit', ['url' => getenv('elastic_audit_dsn')]);
+
+// Connection to general fixture usage
 ConnectionManager::config('test_elastic', ['url' => getenv('elastic_dsn')]);


### PR DESCRIPTION
 - Upgrade cakephp/elastic-search to 2.0-beta
 - Change Type to Index class
 - Update phpunit usage, for newer versions
 - Require PHP >= 7, as current stable version of Elastica
 - Minors typo fix