### PR TITLE
#30 fixing cakephp 3.6 deprecation warnings

### DIFF
--- a/src/Meta/RequestMetadata.php
+++ b/src/Meta/RequestMetadata.php
@@ -61,7 +61,7 @@ class RequestMetadata implements EventListenerInterface
     {
         $meta = [
             'ip' => $this->request->clientIp(),
-            'url' => $this->request->here(),
+            'url' => $this->request->getRequestTarget(),
             'user' => $this->user
         ];
 

--- a/src/Shell/ElasticMappingShell.php
+++ b/src/Shell/ElasticMappingShell.php
@@ -19,7 +19,7 @@ class ElasticMappingShell extends Shell
     public function getOptionParser()
     {
         return parent::getOptionParser()
-            ->description('Creates type mappings in elastic search for the tables you want tracked with audit logging')
+            ->setDescription('Creates type mappings in elastic search for the tables you want tracked with audit logging')
             ->addArgument('table', [
                 'short' => 't',
                 'help' => 'The name of the database table to inspect and create a mapping for',

--- a/src/Shell/Task/ElasticImportTask.php
+++ b/src/Shell/Task/ElasticImportTask.php
@@ -19,7 +19,7 @@ class ElasticImportTask extends Shell
     public function getOptionParser()
     {
         return parent::getOptionParser()
-            ->description('Imports audit logs from the legacy audit logs tables into elastic search')
+            ->setDescription('Imports audit logs from the legacy audit logs tables into elastic search')
             ->addOption('from', [
                 'short' => 'f',
                 'help' => 'The date from which to start importing audit logs',

--- a/tests/TestCase/Meta/ApplicationMetadataTest.php
+++ b/tests/TestCase/Meta/ApplicationMetadataTest.php
@@ -4,13 +4,13 @@ namespace AuditStash\Test\Meta;
 
 use AuditStash\Event\AuditDeleteEvent;
 use AuditStash\Meta\ApplicationMetadata;
-use Cake\Event\EventManagerTrait;
+use Cake\Event\EventDispatcherTrait;
 use Cake\TestSuite\TestCase;
 
 class ApplicationMetadataTest extends TestCase
 {
 
-    use EventManagerTrait;
+    use EventDispatcherTrait;
 
     /**
      * Tests that metadata is added to the audit log objects.

--- a/tests/TestCase/Meta/RequestMetadataTest.php
+++ b/tests/TestCase/Meta/RequestMetadataTest.php
@@ -4,14 +4,14 @@ namespace AuditStash\Test\Persister;
 
 use AuditStash\Event\AuditDeleteEvent;
 use AuditStash\Meta\RequestMetadata;
-use Cake\Event\EventManagertrait;
+use Cake\Event\EventDispatcherTrait;
 use Cake\Http\ServerRequest as Request;
 use Cake\TestSuite\TestCase;
 
 class RequestMetadataTest extends TestCase
 {
 
-    use EventManagertrait;
+    use EventDispatcherTrait;
 
     /**
      * Tests that request metadata is added to the audit log objects.
@@ -25,7 +25,7 @@ class RequestMetadataTest extends TestCase
         $this->getEventManager()->on($listener);
 
         $request->expects($this->once())->method('clientIp')->will($this->returnValue('12345'));
-        $request->expects($this->once())->method('here')->will($this->returnValue('/things?a=b'));
+        $request->expects($this->once())->method('getRequestTarget')->will($this->returnValue('/things?a=b'));
         $logs[] = new AuditDeleteEvent(1234, 1, 'articles');
         $event = $this->dispatchEvent('AuditStash.beforeLog', ['logs' => $logs]);
 


### PR DESCRIPTION
fixing deprecated code
Cake\Console\ConsoleOptionParser::description() to setDescription()
Cake\Http\ServerRequest::here() to getRequestTarget()