### PR TITLE
Fix for Issue 33

### DIFF
--- a/src/Shell/ElasticMappingShell.php
+++ b/src/Shell/ElasticMappingShell.php
@@ -123,7 +123,7 @@ class ElasticMappingShell extends Shell
     /**
      * Returns the correct mapping properties for a table column.
      *
-     * @param Cake\Databse\Schema\Table $schema The table schema
+     * @param \Cake\Database\Schema\TableSchema $schema The table schema
      * @param string $column The column name to instrospect
      * @return array
      */
@@ -134,7 +134,7 @@ class ElasticMappingShell extends Shell
         case 'uuid':
             return ['type' => 'text', 'index' => false, 'null_value' => '_null_'];
         case 'integer':
-            return ['type' => 'integer', 'null_value' => ~PHP_INT_MAX];
+            return ['type' => 'integer', 'null_value' => pow(-2,31)];
         case 'date':
             return ['type' => 'date', 'format' => 'dateOptionalTime||basic_date||yyy-MM-dd', 'null_value' => '0001-01-01'];
         case 'datetime':
@@ -142,18 +142,18 @@ class ElasticMappingShell extends Shell
             return ['type' => 'date', 'format' => 'basic_t_time_no_millis||dateOptionalTime||basic_date_time||ordinal_date_time_no_millis||yyyy-MM-dd HH:mm:ss||basic_date', 'null_value' => '0001-01-01 00:00:00'];
         case 'float':
         case 'decimal':
-            return ['type' => 'float', 'null_value' => ~PHP_INT_MAX];
+            return ['type' => 'float', 'null_value' => pow(-2,31)];
         case 'float':
         case 'decimal':
-            return ['type' => 'float', 'null_value' => ~PHP_INT_MAX];
+            return ['type' => 'float', 'null_value' => pow(-2,31)];
         case 'boolean':
             return ['type' => 'boolean'];
         default:
             return [
-                'type' => 'multi_field',
+                'type' => 'text',
                 'fields' => [
-                    $column => ['type' => 'text', 'null_value' => '_null_'],
-                    'raw' => ['type' => 'text', 'index' => false, 'null_value' => '_null_', 'ignore_above' => 256]
+                    $column => ['type' => 'text'],
+                    'raw' => ['type' => 'text', 'index' => false]
                 ]
             ];
         }


### PR DESCRIPTION
Fix for [https://github.com/lorenzo/audit-stash/issues/33](https://github.com/lorenzo/audit-stash/issues/33)

```
Failed to parse mapping [user]: Value [-9223372036854775808] is out of range for an integer
```
- Elastic 6x integer value: 2^31 = **2147483648**
```
Failed to parse mapping [user]: No handler for type [multi_field] declared on field [password]
```
- **multi_field** is removed (replaced with fields in Elastic 6x)
```
Failed to parse mapping [user]: Mapping definition for [fields] has unsupported parameters:  [null_value : _null_] [ignore_above : 256]
```
- **null_value** is not supported for text fields Elastic 6x
- **ignore_above** is not supported for text fields Elastic 6x