### PR TITLE
Adds afterSave and resolves deprecations in test suite - cake 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,20 @@ The configuration contains the fully namespaced class name of your persister.
 ### Working With Transactional Queries
 
 Occasionally, you may want to wrap a number of database changes in a transaction, so that it can be rolled back if one
-part of the process fails. In order to create audit logs during a transaction, some additional setup is required. First
-create the file `src/Model/Audit/AuditTrail.php` with the following:
+part of the process fails. There are two ways to accomplish this. The easiest is to change your save strategy to use
+`afterSave` instead of `afterCommit`. In your applications configuration, such as `config/app.php`:
+
+```php
+'AuditStash' => [
+    'saveType' => 'afterSave',
+]
+```
+
+That's it if you use afterSave. You should read up on the difference between the two as there are drawbacks:
+https://book.cakephp.org/4/en/orm/table-objects.html#aftersave
+
+If you are using the default afterCommit, in order to create audit logs during a transaction, some additional setup is
+required. First create the file `src/Model/Audit/AuditTrail.php` with the following:
 
 ```php
 <?php

--- a/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
+++ b/tests/TestCase/Model/Behavior/AuditIntegrationTest.php
@@ -9,6 +9,7 @@ use AuditStash\Event\AuditUpdateEvent;
 use AuditStash\Model\Behavior\AuditLogBehavior;
 use AuditStash\PersisterInterface;
 use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 
 class DebugPersister implements PersisterInterface
@@ -34,6 +35,9 @@ class AuditIntegrationTest extends TestCase
         'core.Tags',
         'core.ArticlesTags',
     ];
+
+    private ?Table $table;
+    private mixed $persister;
 
     /**
      * tests setup.

--- a/tests/TestCase/Model/Behavior/AuditLogBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/AuditLogBehaviorTest.php
@@ -15,6 +15,9 @@ use SplObjectStorage;
 
 class AuditLogBehaviorTest extends TestCase
 {
+    private ?Table $table;
+    private ?AuditLogBehavior $behavior;
+
     public function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
Ports this from 3.x: #72 

Misc:

- Resolves `Creation of dynamic property` deprecation warnings in test suite.