### PR TITLE
Implement __serialize to avoid deprecation warning on php 8.2

### DIFF
--- a/src/Event/SerializableEventTrait.php
+++ b/src/Event/SerializableEventTrait.php
@@ -14,7 +14,15 @@ trait SerializableEventTrait
      */
     public function serialize()
     {
-        return serialize(get_object_vars($this));
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function __serialize()
+    {
+        return get_object_vars($this);
     }
 
     /**

--- a/src/Event/SerializableEventTrait.php
+++ b/src/Event/SerializableEventTrait.php
@@ -33,19 +33,18 @@ trait SerializableEventTrait
      */
     public function unserialize($data)
     {
-        $this->__unserialize($data);
+        $this->__unserialize(unserialize($data));
     }
 
     /**
-     * Takes the string representation of this object so it can be reconstructed.
+     * Reconstructs the object from serialization data
      *
-     * @param string $data serialized string
+     * @param array<string,mixed> $data Serialization data
      * @return void
      */
     public function __unserialize($data)
     {
-        $vars = unserialize($data);
-        foreach ($vars as $var => $value) {
+        foreach ($data as $var => $value) {
             $this->{$var} = $value;
         }
     }


### PR DESCRIPTION
Fixes the following on PHP 8.2:

```
AuditStash\Event\AuditUpdateEvent implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)
```