### PR TITLE
Fix double-save when save type is afterSave

### DIFF
--- a/src/Model/Behavior/AuditLogBehavior.php
+++ b/src/Model/Behavior/AuditLogBehavior.php
@@ -55,8 +55,6 @@ class AuditLogBehavior extends Behavior
             'Model.beforeDelete' => 'injectTracking',
             'Model.afterSave' => 'afterSave',
             'Model.afterDelete' => 'afterDelete',
-            'Model.afterSaveCommit' => 'afterCommit',
-            'Model.afterDeleteCommit' => 'afterCommit',
         ];
 
         if (Configure::read('AuditStash.saveType') !== 'afterSave') {


### PR DESCRIPTION
There was a bug when up-porting this from `3.x` causing double-save to the log. When `'AuditStash.saveType'`  is `"afterSave"` then after commit event listeners should not be added.